### PR TITLE
Introduce different status for cities JSON

### DIFF
--- a/App/__init__.py
+++ b/App/__init__.py
@@ -76,6 +76,10 @@ def get_cities_geojson():
     features = list()
     
     for city in data.cities:
+        if city.get('status') == 'pre-published':
+            # Skip any city that is not yet fully published.
+            continue
+    
         x1, y1, x2, y2 = [float(city['bbox'][k])
                           for k in ('left', 'bottom', 'right', 'top')]
 
@@ -92,6 +96,7 @@ def get_cities_geojson():
 @blueprint.route('/cities-extractor.json')
 @util.errors_logged
 def get_cities_extractor_json():
+    # Include only cities that have not been deprecated.
     cities = [city for city in data.cities
               if city.get('status') != 'deprecated']
 

--- a/App/__init__.py
+++ b/App/__init__.py
@@ -12,20 +12,10 @@ from flask import (
     Blueprint, jsonify, Response, render_template, url_for, request, session
     )
 
-from . import util
+from . import util, data
 from .oauth import session_info
 
 blueprint = Blueprint('Metro-Extracts', __name__)
-
-def load_cities(filename):
-    '''
-    '''
-    with open(filename) as file:
-        cities = json.load(file)
-    
-    return cities
-
-cities = load_cities(join(dirname(__file__), '..', 'cities.json'))
 
 def apply_blueprint(app, url_prefix):
     '''
@@ -65,7 +55,7 @@ def populate_metro_urls(metro_id):
 @util.errors_logged
 def index():
     id, nick, avatar, _, _ = session_info(session)
-    ordered_cities = sorted(cities, key=itemgetter('country'))
+    ordered_cities = sorted(data.cities, key=itemgetter('country'))
     metros_tree = list()
     
     for (country, sub_cities) in groupby(ordered_cities, itemgetter('country')):
@@ -85,7 +75,7 @@ def index():
 def get_cities_geojson():
     features = list()
     
-    for city in cities:
+    for city in data.cities:
         x1, y1, x2, y2 = [float(city['bbox'][k])
                           for k in ('left', 'bottom', 'right', 'top')]
 
@@ -102,7 +92,7 @@ def get_cities_geojson():
 @blueprint.route('/cities-extractor.json')
 @util.errors_logged
 def get_cities_extractor_json():
-    return Response(json.dumps(cities, indent=2),
+    return Response(json.dumps(data.cities, indent=2),
                     headers={'Content-Type': 'application/json'})
 
 @blueprint.route('/metro/<metro_id>/')

--- a/App/__init__.py
+++ b/App/__init__.py
@@ -92,7 +92,10 @@ def get_cities_geojson():
 @blueprint.route('/cities-extractor.json')
 @util.errors_logged
 def get_cities_extractor_json():
-    return Response(json.dumps(data.cities, indent=2),
+    cities = [city for city in data.cities
+              if city.get('status') != 'deprecated']
+
+    return Response(json.dumps(cities, indent=2),
                     headers={'Content-Type': 'application/json'})
 
 @blueprint.route('/metro/<metro_id>/')

--- a/App/data.py
+++ b/App/data.py
@@ -1,6 +1,18 @@
 from uuid import uuid4
+from os.path import dirname, join
 from contextlib import contextmanager
 import psycopg2, psycopg2.extras
+import json
+
+def load_cities(filename):
+    '''
+    '''
+    with open(filename) as file:
+        cities = json.load(file)
+    
+    return cities
+
+cities = load_cities(join(dirname(__file__), '..', 'cities.json'))
 
 class Envelope:
     def __init__(self, id, bbox):

--- a/cities.json
+++ b/cities.json
@@ -61,6 +61,7 @@
     },
     {
         "id": "algiers_algeria",
+        "status": "deprecated",
         "name": "Algiers",
         "region": "africa",
         "country": "Algeria",
@@ -69,6 +70,19 @@
             "left": "3.026",
             "bottom": "36.744",
             "right": "3.058"
+        }
+    },
+    {
+        "id": "algiers_algeria_expanded",
+        "status": "pre-published",
+        "name": "Algiers",
+        "region": "africa",
+        "country": "Algeria",
+        "bbox": {
+            "top": "36.847",
+            "left": "2.828",
+            "bottom": "36.567",
+            "right": "3.392"
         }
     },
     {

--- a/test.py
+++ b/test.py
@@ -142,6 +142,14 @@ class TestApp (unittest.TestCase):
                         "region": "africa",
                         "country": "Algeria",
                         "bbox": {"top": "36.762", "left": "3.026", "bottom": "36.744", "right": "3.058"}
+                    },
+                    {
+                        "id": "algiers_algeria-2",
+                        "status": "pre-published",
+                        "name": "Algiers",
+                        "region": "africa",
+                        "country": "Algeria",
+                        "bbox": {"top": "36.847", "left": "2.828", "bottom": "36.567", "right": "3.392"}
                     }
                 ]
             resp1 = self.client.get(self.prefixed('/cities.geojson'))
@@ -160,7 +168,7 @@ class TestApp (unittest.TestCase):
         self.assertEqual(geojson['features'][2]['type'], 'Feature')
         self.assertEqual(geojson['features'][2]['id'], 'algiers_algeria')
         
-        self.assertEqual(len(cities), 2, 'Should see two published cities')
+        self.assertEqual(len(cities), 3, 'Should see three published or pre-published cities')
         
         self.assertEqual(cities[0]['id'], 'abidjan_ivory-coast')
         self.assertEqual(cities[0]['bbox']['top'], '5.523')
@@ -168,6 +176,7 @@ class TestApp (unittest.TestCase):
         self.assertEqual(cities[0]['bbox']['bottom'], '5.220')
         self.assertEqual(cities[0]['bbox']['right'], '-3.849')
         self.assertEqual(cities[1]['id'], 'abuja_nigeria')
+        self.assertEqual(cities[2]['id'], 'algiers_algeria-2')
         
     def test_oauth_index(self):
         resp = self.client.get(self.prefixed('/oauth/hello'))

--- a/test.py
+++ b/test.py
@@ -159,7 +159,12 @@ class TestApp (unittest.TestCase):
             cities = json.loads(resp2.data.decode('utf8'))
             
             resp3 = self.client.get(self.prefixed('/'))
-            html = resp3.data.decode('utf8')
+            index_html = resp3.data.decode('utf8')
+            
+            resp4 = self.client.get(self.prefixed('/metro/abidjan_ivory-coast/'))
+            resp5 = self.client.get(self.prefixed('/metro/abuja_nigeria/'))
+            resp6 = self.client.get(self.prefixed('/metro/algiers_algeria:deprecated/'))
+            resp7 = self.client.get(self.prefixed('/metro/algiers_algeria:pre-published/'))
         
         self.assertEqual(geojson['type'], 'FeatureCollection')
         self.assertEqual(len(geojson['features']), 3, 'Should see three published or deprecated cities')
@@ -181,10 +186,15 @@ class TestApp (unittest.TestCase):
         self.assertEqual(cities[1]['id'], 'abuja_nigeria')
         self.assertEqual(cities[2]['id'], 'algiers_algeria:pre-published')
         
-        self.assertIn('abidjan_ivory-coast', html)
-        self.assertIn('abuja_nigeria', html)
-        self.assertIn('algiers_algeria:deprecated', html)
-        self.assertNotIn('algiers_algeria:pre-published', html)
+        self.assertIn('abidjan_ivory-coast', index_html)
+        self.assertIn('abuja_nigeria', index_html)
+        self.assertIn('algiers_algeria:deprecated', index_html)
+        self.assertNotIn('algiers_algeria:pre-published', index_html)
+        
+        self.assertEqual(resp4.status_code, 200)
+        self.assertEqual(resp5.status_code, 200)
+        self.assertEqual(resp6.status_code, 200)
+        self.assertNotEqual(resp7.status_code, 200)
         
     def test_oauth_index(self):
         resp = self.client.get(self.prefixed('/oauth/hello'))

--- a/test.py
+++ b/test.py
@@ -134,6 +134,14 @@ class TestApp (unittest.TestCase):
                         "region": "africa",
                         "country": "Nigeria",
                         "bbox": {"top": "9.246", "left": "7.248", "bottom": "8.835", "right": "7.717"}
+                    },
+                    {
+                        "id": "algiers_algeria",
+                        "status": "deprecated",
+                        "name": "Algiers",
+                        "region": "africa",
+                        "country": "Algeria",
+                        "bbox": {"top": "36.762", "left": "3.026", "bottom": "36.744", "right": "3.058"}
                     }
                 ]
             resp1 = self.client.get(self.prefixed('/cities.geojson'))
@@ -143,14 +151,16 @@ class TestApp (unittest.TestCase):
             cities = json.loads(resp2.data.decode('utf8'))
         
         self.assertEqual(geojson['type'], 'FeatureCollection')
-        self.assertEqual(len(geojson['features']), 2)
+        self.assertEqual(len(geojson['features']), 3, 'Should see three published or deprecated cities')
         
         self.assertEqual(geojson['features'][0]['type'], 'Feature')
         self.assertEqual(geojson['features'][0]['id'], 'abidjan_ivory-coast')
         self.assertEqual(geojson['features'][1]['type'], 'Feature')
         self.assertEqual(geojson['features'][1]['id'], 'abuja_nigeria')
+        self.assertEqual(geojson['features'][2]['type'], 'Feature')
+        self.assertEqual(geojson['features'][2]['id'], 'algiers_algeria')
         
-        self.assertEqual(len(cities), 2)
+        self.assertEqual(len(cities), 2, 'Should see two published cities')
         
         self.assertEqual(cities[0]['id'], 'abidjan_ivory-coast')
         self.assertEqual(cities[0]['bbox']['top'], '5.523')

--- a/test.py
+++ b/test.py
@@ -126,6 +126,14 @@ class TestApp (unittest.TestCase):
                         "region": "africa",
                         "country": "Ivory Coast",
                         "bbox": {"top": "5.523", "left": "-4.183", "bottom": "5.220", "right": "-3.849"}
+                    },
+                    {
+                        "id": "abuja_nigeria",
+                        "status": "published",
+                        "name": "Abuja",
+                        "region": "africa",
+                        "country": "Nigeria",
+                        "bbox": {"top": "9.246", "left": "7.248", "bottom": "8.835", "right": "7.717"}
                     }
                 ]
             resp1 = self.client.get(self.prefixed('/cities.geojson'))
@@ -135,18 +143,21 @@ class TestApp (unittest.TestCase):
             cities = json.loads(resp2.data.decode('utf8'))
         
         self.assertEqual(geojson['type'], 'FeatureCollection')
-        self.assertEqual(len(geojson['features']), 1)
+        self.assertEqual(len(geojson['features']), 2)
         
         self.assertEqual(geojson['features'][0]['type'], 'Feature')
         self.assertEqual(geojson['features'][0]['id'], 'abidjan_ivory-coast')
+        self.assertEqual(geojson['features'][1]['type'], 'Feature')
+        self.assertEqual(geojson['features'][1]['id'], 'abuja_nigeria')
         
-        self.assertEqual(len(cities), 1)
+        self.assertEqual(len(cities), 2)
         
         self.assertEqual(cities[0]['id'], 'abidjan_ivory-coast')
         self.assertEqual(cities[0]['bbox']['top'], '5.523')
         self.assertEqual(cities[0]['bbox']['left'], '-4.183')
         self.assertEqual(cities[0]['bbox']['bottom'], '5.220')
         self.assertEqual(cities[0]['bbox']['right'], '-3.849')
+        self.assertEqual(cities[1]['id'], 'abuja_nigeria')
         
     def test_oauth_index(self):
         resp = self.client.get(self.prefixed('/oauth/hello'))

--- a/test.py
+++ b/test.py
@@ -117,7 +117,7 @@ class TestApp (unittest.TestCase):
         self.assertEqual(resp2.status_code, 200)
         self.assertIn('San Francisco', head2)
     
-    def test_cities_json_responses(self):
+    def test_cities_responses(self):
         with mock.patch('App.data') as data:
             data.cities = [
                     {
@@ -136,7 +136,7 @@ class TestApp (unittest.TestCase):
                         "bbox": {"top": "9.246", "left": "7.248", "bottom": "8.835", "right": "7.717"}
                     },
                     {
-                        "id": "algiers_algeria",
+                        "id": "algiers_algeria:deprecated",
                         "status": "deprecated",
                         "name": "Algiers",
                         "region": "africa",
@@ -144,7 +144,7 @@ class TestApp (unittest.TestCase):
                         "bbox": {"top": "36.762", "left": "3.026", "bottom": "36.744", "right": "3.058"}
                     },
                     {
-                        "id": "algiers_algeria-2",
+                        "id": "algiers_algeria:pre-published",
                         "status": "pre-published",
                         "name": "Algiers",
                         "region": "africa",
@@ -157,6 +157,9 @@ class TestApp (unittest.TestCase):
 
             resp2 = self.client.get(self.prefixed('/cities-extractor.json'))
             cities = json.loads(resp2.data.decode('utf8'))
+            
+            resp3 = self.client.get(self.prefixed('/'))
+            html = resp3.data.decode('utf8')
         
         self.assertEqual(geojson['type'], 'FeatureCollection')
         self.assertEqual(len(geojson['features']), 3, 'Should see three published or deprecated cities')
@@ -166,7 +169,7 @@ class TestApp (unittest.TestCase):
         self.assertEqual(geojson['features'][1]['type'], 'Feature')
         self.assertEqual(geojson['features'][1]['id'], 'abuja_nigeria')
         self.assertEqual(geojson['features'][2]['type'], 'Feature')
-        self.assertEqual(geojson['features'][2]['id'], 'algiers_algeria')
+        self.assertEqual(geojson['features'][2]['id'], 'algiers_algeria:deprecated')
         
         self.assertEqual(len(cities), 3, 'Should see three published or pre-published cities')
         
@@ -176,7 +179,12 @@ class TestApp (unittest.TestCase):
         self.assertEqual(cities[0]['bbox']['bottom'], '5.220')
         self.assertEqual(cities[0]['bbox']['right'], '-3.849')
         self.assertEqual(cities[1]['id'], 'abuja_nigeria')
-        self.assertEqual(cities[2]['id'], 'algiers_algeria-2')
+        self.assertEqual(cities[2]['id'], 'algiers_algeria:pre-published')
+        
+        self.assertIn('abidjan_ivory-coast', html)
+        self.assertIn('abuja_nigeria', html)
+        self.assertIn('algiers_algeria:deprecated', html)
+        self.assertNotIn('algiers_algeria:pre-published', html)
         
     def test_oauth_index(self):
         resp = self.client.get(self.prefixed('/oauth/hello'))

--- a/test.py
+++ b/test.py
@@ -652,6 +652,11 @@ class TestAppDoublePrefix (TestApp):
 
 class TestData (unittest.TestCase):
 
+    def test_cities_json_content(self):
+        values = (None, 'published', 'pre-published', 'deprecated')
+        for city in data.cities:
+            self.assertIn(city.get('status'), values, 'Bad status in city {id}'.format(**city))
+
     def test_add_extract_envelope(self):
         db, name = Mock(), str(uuid4())
         envelope = data.Envelope('xyz', [-122.26447, 37.79724, -122.24825, 37.81230])


### PR DESCRIPTION
Metroextractor now pulls city data from https://mapzen.com/data/metro-extracts/cities-extractor.json. This PR introduces three possible status values for each city to control extractor behavior:

* `"published"` (default) — show this metro on the map and feed it to extractor batch.
* `"deprecated"` — show this metro on the map, but hide it from extractor batch.
* `"pre-published"` — omit this metro from the map, but feed it to extractor batch.

The difference between deprecated and pre-published can be seen between https://mapzen-odes-extracts-pr-274.herokuapp.com/metro/algiers_algeria/ and https://mapzen-odes-extracts-pr-274.herokuapp.com/cities-extractor.json, with `algiers_algeria` representing an old bbox for Algiers, and `algiers_algeria_expanded` showing a new one. In practice, we would want some amount of lead time in pre-published status, and then switch to published once we knew that the files existed on S3.

Closes https://github.com/mapzen/operations-engineering/issues/354