### PR TITLE
Pinned Mapzen.js to 0.4

### DIFF
--- a/App/templates/layout.html
+++ b/App/templates/layout.html
@@ -24,7 +24,7 @@
   </div>
   
   <script src="https://d3js.org/d3.v3.min.js" charset="utf-8"></script>
-  <script src="https://mapzen.com/js/mapzen.min.js"></script>
+  <script src="https://mapzen.com/js/0.4/mapzen.min.js"></script>
   {% block js %}{% endblock %}
   <script type="text/javascript">
     {% block script %}{% endblock %}


### PR DESCRIPTION
A newer version of Mapzen.js were preventing clickable areas from working; this fix will buy us a bit of time by pinning the version to [Mapzen.js 0.4](https://github.com/mapzen/mapzen.js/releases/tag/release-v0.4.5).

Closes #287.